### PR TITLE
Report repo path to help detect config mismatch on project fork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gurney_client (0.2.3)
+    gurney_client (0.4.0)
       bundler (< 3)
       colorize (~> 0.8)
       git (~> 1.5)
@@ -10,22 +10,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     byebug (11.0.1)
     colorize (0.8.1)
     diff-lcs (1.3)
-    git (1.18.0)
+    git (1.19.1)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     httparty (0.17.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    mime-types (3.4.1)
+    logger (1.6.1)
+    mime-types (3.6.0)
+      logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
+    mime-types-data (3.2024.1105)
     multi_xml (0.6.0)
-    public_suffix (5.0.1)
+    public_suffix (5.1.1)
     rake (13.0.1)
     rchardet (1.8.0)
     rspec (3.9.0)
@@ -52,4 +54,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.2.27
+   2.3.19

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-## Gurney
+# Gurney
 
-Gurney is a small tool to extract dependencies from project files and report them to a web api.
-It can either run locally or as a git post-receive hook in gitlab.
+Gurney is a small tool to extract dependencies from project files and report
+them to a web API. Modes:
+- normal
+- local pre-push hook
+- remote post-receive hook
+Usually, we configure the latter on our Git server to automatically run on each
+push, with the API url passed as command line option.
 
-When run as a git hook, the project gets cloned on the git server and gurney then looks for a `gurney.yml` within the project files. 
-If its present gurney looks at the pushed branches and analyses the ones specified in the config for dependencies. 
-It then reports them to the web api also specified in the config.
+When run as a post-receive hook, Gurney will make a bare copy of the project and 
+look for a gurney.yml file. If present, Gurney looks at the configured branches
+and collects their dependencies. These are reported to the web API.
 
-#### Usage:
+## Usage
 ```
 Usage: gurney [options]
-        --api-url [API URL]
-                                     Url for web api call, can have parameters for <project_id> and <branch>
-                                     example: --api-url "http://example.com/project/<project_id>/branch/<branch>"
-        --api-token [API TOKEN]
-                                     Token to be send to the api in the X-AuthToken header
+        --api-url [API URL]          Url for web API call, can have parameters for <project_id> and <branch>
+                                     Example: --api-url "https://example.com/project/<project_id>/branch/<branch>"
+        --api-token [API TOKEN]      Token to be sent to the API in the X-AuthToken header
     -c, --config [CONFIG FILE]       Config file to use
-    -h, --hook                       Run as a git post-receive hook
-        --client-hook
-                                     Run as a git pre-push hook
-    -p, --project-id [PROJECT ID]    Specify project id for api
-        --help
-                                     Prints this help
+    -h, --hook                       Run as a Git post-receive hook
+        --client-hook                Run as a Git pre-push hook
+    -p, --project-id [PROJECT ID]    Specify project id for API
+        --help                       Print this help
 ```
 
-#### Sample Config:
+## Sample Config
 ```yaml
 project_id: 1
 branches:
@@ -34,5 +35,13 @@ api_url: http://example.com/dep_reporter/project/<project_id>/branch/<branch>
 api_token: 1234567890
 ```
 
-##### Running as a global git hook
-To run as a global git hook in your gitlab see https://docs.gitlab.com/ee/administration/custom_hooks.html#set-a-global-git-hook-for-all-repositories
+## Running as a global Git hook
+See https://docs.gitlab.com/ee/administration/server_hooks.html#create-global-server-hooks-for-all-repositories
+
+## Development
+You can run Gurney locally from another directory like this:
+
+```bash
+cd some/real/project
+ruby -I path/to/gurney/lib path/to/gurney/exe/gurney
+```

--- a/lib/gurney/api.rb
+++ b/lib/gurney/api.rb
@@ -9,13 +9,14 @@ module Gurney
       @token = token
     end
 
-    def post_dependencies(dependencies:, branch:, project_id:)
-      data = {
-          dependencies: dependencies
-      }
+    def post_dependencies(dependencies:, branch:, project_id:, repo_path: nil)
+      data = { dependencies: dependencies }
+      data[:repository_path] = repo_path if repo_path
+
       url = base_url
       url.gsub! '<project_id>', CGI.escape(project_id)
       url.gsub! '<branch>', CGI.escape(branch)
+
       post_json(url, data.to_json)
     end
 
@@ -31,7 +32,7 @@ module Gurney
       )
       unless response.success?
         if response.code == 404
-          raise ApiError.new("#{response.code} api url is probably wrong")
+          raise ApiError.new("#{response.code} API url is probably wrong")
         else
           raise ApiError.new("#{response.code} #{response.body}")
         end

--- a/lib/gurney/cli.rb
+++ b/lib/gurney/cli.rb
@@ -6,28 +6,45 @@ require 'git'
 require 'fileutils'
 
 module Gurney
+
+  class Error < StandardError; end
+
   class CLI
     HOOK_STDIN_REGEX = /(?<old>[0-9a-f]{40}) (?<new>[0-9a-f]{40}) refs\/heads\/(?<ref>\w+)/m
     CLIENT_HOOK_STDIN_REGEX = /refs\/heads\/(?<ref>\w+) (?<new>[0-9a-f]{40}) refs\/heads\/(?<remote_ref>\w+) (?<remote_sha>[0-9a-f]{40})/m
     MAIN_BRANCHES = ['master', 'main'].freeze
 
     def self.run(cmd_parameter=[])
-      options = Gurney::CLI::OptionParser.parse(cmd_parameter)
+      new(cmd_parameter).run
+    rescue SystemExit
+      # Do nothing
+    rescue Gurney::ApiError => e
+      puts "Gurney API error".red
+      puts e.message.red
+    rescue Gurney::Error => e
+      puts "Gurney error: #{e.message}".red
+    rescue Exception
+      puts "Gurney: an unexpected error occurred".red
+      raise
+    end
 
-      if options.hook
-        g = Git.bare(ENV['GIT_DIR'] || Dir.pwd)
+    def initialize(cmd_parameter=[])
+      @options = Gurney::CLI::OptionParser.parse(cmd_parameter)
+      @git = if options.hook
+        Git.bare(ENV['GIT_DIR'] || Dir.pwd)
       else
         unless Dir.exist? './.git'
           raise Gurney::Error.new('Must be run within a git repository')
         end
-        g = Git.open('.')
+        Git.open('.')
       end
+
       config_file = MAIN_BRANCHES.find do |branch|
-        file = read_file(g, options.hook, branch, options.config_file)
+        file = read_file(options.hook, branch, options.config_file)
         break file if file
       end
-      if !config_file && options.hook
-        # dont run as a hook with no config
+      if options.hook && !config_file
+        # Git hooks are activated by the config file. Without, do nothing.
         exit 0
       end
       config_file ||= '---'
@@ -39,42 +56,23 @@ module Gurney
       options.api_url ||= config&.api_url
       options.project_id ||= config&.project_id
 
-      if [options.project_id, options.branches, options.api_url, options.api_token].any?(&:nil?)
-        raise Gurney::Error.new("Either provide in a config file or set the flags for project id, branches, api url and api token")
-      end
+      missing_options = [:project_id, :branches, :api_url, :api_token].select { |option| options.send(option).nil? }
+      # Use the line below in development
+      # missing_options = [:project_id, :branches, :api_token].select { |option| options.send(option).nil? }
+      raise Gurney::Error.new("Incomplete config - missing #{missing_options.map(&:inspect).join(', ')}.") unless missing_options.empty?
+    end
 
-      branches = []
-      if options.hook || options.client_hook
-        # we get passed changed branches and refs via stdin
-        $stdin.each_line do |line|
-          regex = options.client_hook ? CLIENT_HOOK_STDIN_REGEX : HOOK_STDIN_REGEX
-          line.force_encoding(Encoding::UTF_8)
-          matches = line.match(regex)
-          if matches && matches[:new] != '0' * 40
-            if options.branches.include? matches[:ref]
-              branches << matches[:ref]
-            end
-          end
-        end
-
-      else
-        current_branch = g.current_branch
-        unless options.branches.nil? || options.branches.include?(current_branch)
-          raise Gurney::Error.new('The current branch is not specified in the config.')
-        end
-        branches << current_branch
-      end
-
-      branches.each do |branch|
+    def run
+      get_branches.each do |branch|
         dependencies = []
 
-        yarn_source = Gurney::Source::Yarn.new(yarn_lock: read_file(g, options.hook || options.client_hook, branch, 'yarn.lock'))
+        yarn_source = Gurney::Source::Yarn.new(yarn_lock: read_file(options.hook || options.client_hook, branch, 'yarn.lock'))
         dependencies.concat yarn_source.dependencies || []
 
-        bundler_source = Gurney::Source::Bundler.new(gemfile_lock: read_file(g, options.hook || options.client_hook, branch, 'Gemfile.lock'))
+        bundler_source = Gurney::Source::Bundler.new(gemfile_lock: read_file(options.hook || options.client_hook, branch, 'Gemfile.lock'))
         dependencies.concat bundler_source.dependencies || []
 
-        ruby_version_source = Gurney::Source::RubyVersion.new(ruby_version: read_file(g, options.hook || options.client_hook, branch, '.ruby-version'))
+        ruby_version_source = Gurney::Source::RubyVersion.new(ruby_version: read_file(options.hook || options.client_hook, branch, '.ruby-version'))
         dependencies.concat ruby_version_source.dependencies || []
 
         dependencies.compact!
@@ -85,22 +83,39 @@ module Gurney
         dependency_counts = dependencies.group_by(&:ecosystem).map{|ecosystem, dependencies| "#{ecosystem}: #{dependencies.count}" }.join(', ')
         puts "Gurney: reported dependencies (#{dependency_counts})"
       end
-
-    rescue SystemExit
-    rescue Gurney::ApiError => e
-      puts "Gurney: api error".red
-      puts e.message.red
-    rescue Gurney::Error => e
-      puts "Gurney: error".red
-        puts e.message.red
-    rescue Exception
-      puts "Gurney: an unexpected error occurred".red
-      raise
     end
 
     private
 
-    def self.read_file(git, from_git, branch, filename)
+    attr_accessor :git, :options
+
+    def get_branches
+      branches = []
+      if options.hook || options.client_hook
+        # We get changed branches and refs via stdin
+        # See https://git-scm.com/docs/githooks#post-receive
+        $stdin.each_line do |line|
+          regex = options.client_hook ? CLIENT_HOOK_STDIN_REGEX : HOOK_STDIN_REGEX
+          line.force_encoding(Encoding::UTF_8)
+          matches = line.match(regex)
+          if matches && matches[:new] != '0' * 40
+            if options.branches.include? matches[:ref]
+              branches << matches[:ref]
+            end
+          end
+        end
+      else
+        current_branch = git.current_branch
+        unless options.branches.nil? || options.branches.include?(current_branch)
+          raise Gurney::Error.new('The current branch is not specified in the config.')
+        end
+        branches << current_branch
+      end
+
+      branches
+    end
+
+    def read_file(from_git, branch, filename)
       if from_git
         begin
           git.show("#{branch}:#{filename}")
@@ -108,14 +123,9 @@ module Gurney
           # happens if branch does not exist
         end
       else
-        if File.exist? filename
-          return File.read filename
-        end
+        File.read(filename) if File.exist?(filename)
       end
     end
 
-  end
-
-  class Error < Exception
   end
 end

--- a/lib/gurney/cli.rb
+++ b/lib/gurney/cli.rb
@@ -14,90 +14,88 @@ module Gurney
     def self.run(cmd_parameter=[])
       options = Gurney::CLI::OptionParser.parse(cmd_parameter)
 
-      begin
-        if options.hook
-          g = Git.bare(ENV['GIT_DIR'] || Dir.pwd)
-        else
-          unless Dir.exist? './.git'
-            raise Gurney::Error.new('Must be run within a git repository')
-          end
-          g = Git.open('.')
+      if options.hook
+        g = Git.bare(ENV['GIT_DIR'] || Dir.pwd)
+      else
+        unless Dir.exist? './.git'
+          raise Gurney::Error.new('Must be run within a git repository')
         end
-        config_file = MAIN_BRANCHES.find do |branch|
-          file = read_file(g, options.hook, branch, options.config_file)
-          break file if file
-        end
-        if !config_file && options.hook
-          # dont run as a hook with no config
-          exit 0
-        end
-        config_file ||= '---'
-        config = Gurney::Config.from_yaml(config_file)
+        g = Git.open('.')
+      end
+      config_file = MAIN_BRANCHES.find do |branch|
+        file = read_file(g, options.hook, branch, options.config_file)
+        break file if file
+      end
+      if !config_file && options.hook
+        # dont run as a hook with no config
+        exit 0
+      end
+      config_file ||= '---'
+      config = Gurney::Config.from_yaml(config_file)
 
-        options.branches ||= config&.branches
-        options.branches ||= config&.branches
-        options.api_token ||= config&.api_token
-        options.api_url ||= config&.api_url
-        options.project_id ||= config&.project_id
+      options.branches ||= config&.branches
+      options.branches ||= config&.branches
+      options.api_token ||= config&.api_token
+      options.api_url ||= config&.api_url
+      options.project_id ||= config&.project_id
 
-        if [options.project_id, options.branches, options.api_url, options.api_token].any?(&:nil?)
-          raise Gurney::Error.new("Either provide in a config file or set the flags for project id, branches, api url and api token")
-        end
+      if [options.project_id, options.branches, options.api_url, options.api_token].any?(&:nil?)
+        raise Gurney::Error.new("Either provide in a config file or set the flags for project id, branches, api url and api token")
+      end
 
-        branches = []
-        if options.hook || options.client_hook
-          # we get passed changed branches and refs via stdin
-          $stdin.each_line do |line|
-            regex = options.client_hook ? CLIENT_HOOK_STDIN_REGEX : HOOK_STDIN_REGEX
-            line.force_encoding(Encoding::UTF_8)
-            matches = line.match(regex)
-            if matches && matches[:new] != '0' * 40
-              if options.branches.include? matches[:ref]
-                branches << matches[:ref]
-              end
+      branches = []
+      if options.hook || options.client_hook
+        # we get passed changed branches and refs via stdin
+        $stdin.each_line do |line|
+          regex = options.client_hook ? CLIENT_HOOK_STDIN_REGEX : HOOK_STDIN_REGEX
+          line.force_encoding(Encoding::UTF_8)
+          matches = line.match(regex)
+          if matches && matches[:new] != '0' * 40
+            if options.branches.include? matches[:ref]
+              branches << matches[:ref]
             end
           end
-
-        else
-          current_branch = g.current_branch
-          unless options.branches.nil? || options.branches.include?(current_branch)
-            raise Gurney::Error.new('The current branch is not specified in the config.')
-          end
-          branches << current_branch
         end
 
-        branches.each do |branch|
-          dependencies = []
-
-          yarn_source = Gurney::Source::Yarn.new(yarn_lock: read_file(g, options.hook || options.client_hook, branch, 'yarn.lock'))
-          dependencies.concat yarn_source.dependencies || []
-
-          bundler_source = Gurney::Source::Bundler.new(gemfile_lock: read_file(g, options.hook || options.client_hook, branch, 'Gemfile.lock'))
-          dependencies.concat bundler_source.dependencies || []
-
-          ruby_version_source = Gurney::Source::RubyVersion.new(ruby_version: read_file(g, options.hook || options.client_hook, branch, '.ruby-version'))
-          dependencies.concat ruby_version_source.dependencies || []
-
-          dependencies.compact!
-
-          api = Gurney::Api.new(base_url: options.api_url, token: options.api_token)
-          api.post_dependencies(dependencies: dependencies, branch: branch, project_id: options.project_id)
-
-          dependency_counts = dependencies.group_by(&:ecosystem).map{|ecosystem, dependencies| "#{ecosystem}: #{dependencies.count}" }.join(', ')
-          puts "Gurney: reported dependencies (#{dependency_counts})"
+      else
+        current_branch = g.current_branch
+        unless options.branches.nil? || options.branches.include?(current_branch)
+          raise Gurney::Error.new('The current branch is not specified in the config.')
         end
-
-      rescue SystemExit
-      rescue Gurney::ApiError => e
-        puts "Gurney: api error".red
-        puts e.message.red
-      rescue Gurney::Error => e
-        puts "Gurney: error".red
-        puts e.message.red
-      rescue Exception => e
-        puts "Gurney: an unexpected error occurred".red
-        raise
+        branches << current_branch
       end
+
+      branches.each do |branch|
+        dependencies = []
+
+        yarn_source = Gurney::Source::Yarn.new(yarn_lock: read_file(g, options.hook || options.client_hook, branch, 'yarn.lock'))
+        dependencies.concat yarn_source.dependencies || []
+
+        bundler_source = Gurney::Source::Bundler.new(gemfile_lock: read_file(g, options.hook || options.client_hook, branch, 'Gemfile.lock'))
+        dependencies.concat bundler_source.dependencies || []
+
+        ruby_version_source = Gurney::Source::RubyVersion.new(ruby_version: read_file(g, options.hook || options.client_hook, branch, '.ruby-version'))
+        dependencies.concat ruby_version_source.dependencies || []
+
+        dependencies.compact!
+
+        api = Gurney::Api.new(base_url: options.api_url, token: options.api_token)
+        api.post_dependencies(dependencies: dependencies, branch: branch, project_id: options.project_id)
+
+        dependency_counts = dependencies.group_by(&:ecosystem).map{|ecosystem, dependencies| "#{ecosystem}: #{dependencies.count}" }.join(', ')
+        puts "Gurney: reported dependencies (#{dependency_counts})"
+      end
+
+    rescue SystemExit
+    rescue Gurney::ApiError => e
+      puts "Gurney: api error".red
+      puts e.message.red
+    rescue Gurney::Error => e
+      puts "Gurney: error".red
+        puts e.message.red
+    rescue Exception
+      puts "Gurney: an unexpected error occurred".red
+      raise
     end
 
     private

--- a/lib/gurney/cli.rb
+++ b/lib/gurney/cli.rb
@@ -63,7 +63,7 @@ module Gurney
     end
 
     def run
-      get_branches.each do |branch|
+      reporting_branches.each do |branch|
         dependencies = []
 
         yarn_source = Gurney::Source::Yarn.new(yarn_lock: read_file(options.hook || options.client_hook, branch, 'yarn.lock'))
@@ -78,7 +78,7 @@ module Gurney
         dependencies.compact!
 
         api = Gurney::Api.new(base_url: options.api_url, token: options.api_token)
-        api.post_dependencies(dependencies: dependencies, branch: branch, project_id: options.project_id)
+        api.post_dependencies(dependencies: dependencies, branch: branch, project_id: options.project_id, repo_path: git.repo.path)
 
         dependency_counts = dependencies.group_by(&:ecosystem).map{|ecosystem, dependencies| "#{ecosystem}: #{dependencies.count}" }.join(', ')
         puts "Gurney: reported dependencies (#{dependency_counts})"
@@ -89,7 +89,7 @@ module Gurney
 
     attr_accessor :git, :options
 
-    def get_branches
+    def reporting_branches
       branches = []
       if options.hook || options.client_hook
         # We get changed branches and refs via stdin

--- a/lib/gurney/version.rb
+++ b/lib/gurney/version.rb
@@ -1,3 +1,3 @@
 module Gurney
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
If set, Gurney will compare the configured name with the "origin" remote url and print an error on mismatch. This is handy when a repository gets forked for another project, as it prevents wrong reports.